### PR TITLE
Use Lucene interpolation engine for variables

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -81,7 +81,7 @@ export class TimelionDatasource {
 
   metricFindQuery(query) {
     var interpolated = {
-      target: this.templateSrv.replace(query, null, 'regex')
+      target: this.templateSrv.replace(query, null, 'lucene')
     };
 
     return this.backendSrv.datasourceRequest({


### PR DESCRIPTION
It's likely that when using templates the variables will end up in the 'q' parameter of the Timelion query. Following what the ElasticSearch plugin does the expected syntax there is Lucene so it's probably a good idea to interpolate multi-valued variables using that syntax.

Currently, a multi-valued variable will be replaced as:

```
{"a","b"}
```

whereas

```
("a" OR "b")
```

probably makes more sense.

I have zero experience with Grafana plugins so perhaps this does not make sense at all 😁. Also, the tests might not pass.