### PR TITLE
Use Lucene interpolation engine when building queries

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -125,7 +125,7 @@ export class TimelionDatasource {
       _.map(Object.keys(options.scopedVars), key =>
                    target = target.replace("$"+key, options.scopedVars[key].value));
       return oThis.templateSrv
-            .replace(target, true)
+            .replace(target, true, 'lucene')
             .replace(/\r\n|\r|\n/mg, "")
             .trim();
     };


### PR DESCRIPTION
Along the lines of 9bff0343fcb15edd61c49221cf37ce78ae6023af.

This patch instructs the plugin to use the 'lucene' interpolation engine when building query parameters.

Example query:
```
 "q='bar:$Bar'"
```

After interpolation (unpatched):
```
  'bar:{a,b}'
```

After interpolation (patched):
```
  'bar:"a" OR "b"'
```