### PR TITLE
Fixing multiple parameters to use Lucene format

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -167,7 +167,7 @@ export class TimelionDatasource {
       _.map(Object.keys(options.scopedVars), key =>
         target = target.replace("$" + key, options.scopedVars[key].value));
       return oThis.templateSrv
-        .replace(target, true)
+        .replace(target, true, "lucene")
         .replace(/\r\n|\r|\n/mg, "")
         .trim();
     };

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -165,7 +165,7 @@ export class TimelionDatasource {
     };
     var expandTemplate = function (target) {
       _.map(Object.keys(options.scopedVars), key =>
-        target = target.replace("$" + key, options.scopedVars[key].value));
+        target = target.replace("$" + key, oThis.templateSrv.replace("$" + key, options.scopedVars, "lucene"));
       return oThis.templateSrv
         .replace(target, true, "lucene")
         .replace(/\r\n|\r|\n/mg, "")

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -165,7 +165,7 @@ export class TimelionDatasource {
     };
     var expandTemplate = function (target) {
       _.map(Object.keys(options.scopedVars), key =>
-        target = target.replace("$" + key, oThis.templateSrv.replace("$" + key, options.scopedVars, "lucene"));
+        target = target.replace(new RegExp("\\$" + key, 'g'),  oThis.templateSrv.replace("$" + key, options.scopedVars, "lucene"));
       return oThis.templateSrv
         .replace(target, true)
         .replace(/\r\n|\r|\n/mg, "")

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -167,7 +167,7 @@ export class TimelionDatasource {
       _.map(Object.keys(options.scopedVars), key =>
         target = target.replace("$" + key, oThis.templateSrv.replace("$" + key, options.scopedVars, "lucene"));
       return oThis.templateSrv
-        .replace(target, true, "lucene")
+        .replace(target, true)
         .replace(/\r\n|\r|\n/mg, "")
         .trim();
     };


### PR DESCRIPTION
Hi Brian,

We had problems with substituting Grafana variables into Lucene queries.
Example parametrized Lucene query: `.es(index=pageview_*,metric='sum:value',timefield='timestamp',q='platform: $PLATFORM').label('Current') `

Without the fix it was substituted as:
`.es(index=pageview_*,metric='sum:value',timefield='timestamp',q='platform: {Android,Windows,iOS}').label('Current')  `
which is not a valid Lucene query

After the fix:
`.es(index=pageview_*,metric='sum:value',timefield='timestamp',q='platform: ("Android" OR "Windows" OR "iOS")').label('Current') `
Which is what we want

Would you be so kind to merge this?

Regards,
Máté